### PR TITLE
go.mod: update module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module caddy-socket-activation
+module github.com/WeidiDeng/caddy-socket-activation
 
 go 1.22.0
 


### PR DESCRIPTION
Otherwise, this fails for me with:

```
       > 2024/05/25 13:42:20 [INFO] exec (timeout=0s): /nix/store/6bvndddvxaypc42x6x4ari20gv3vfdgd-go-1.22.2/bin/go get -d -v github.com/WeidiDeng/caddy-socket-activation@2246ae4a7a00955926ebdf1d557c1530b327bf2f github.com/caddyserver/caddy/v2@v2.7.6
       > go: downloading github.com/WeidiDeng/caddy-socket-activation v0.0.0-20240508065503-2246ae4a7a00
       > go: github.com/WeidiDeng/caddy-socket-activation@v0.0.0-20240508065503-2246ae4a7a00 found: parsing go.mod:
       >         module declares its path as: caddy-socket-activation
       >                 but was required as: github.com/WeidiDeng/caddy-socket-activation
       > go: github.com/WeidiDeng/caddy-socket-activation@2246ae4a7a00955926ebdf1d557c1530b327bf2f (v0.0.0-20240508065503-2246ae4a7a00) requires github.com/WeidiDeng/caddy-socket-activation@v0.0.0-20240508065503-2246ae4a7a00: parsing go.mod:
       >         module declares its path as: caddy-socket-activation
       >                 but was required as: github.com/WeidiDeng/caddy-socket-activation
       > 2024/05/25 13:42:34 [FATAL] exit status 1
```

I should note I'm using another custom build process, something similar to [here](https://github.com/fore-stun/flakes/blob/1bc06ffa7b99c57971f7a2a2e83e64a2fd2b05f2/servers/caddy/fetchXCaddy.nix). Though at least [caddy-dns/acmedns' go.mod](https://github.com/caddy-dns/acmedns/blob/main/go.mod) uses a github.com/owner/repo module name.